### PR TITLE
Add public keyword to enum Terminal type

### DIFF
--- a/src/main/java/graphcut/GraphCut.java
+++ b/src/main/java/graphcut/GraphCut.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * The two possible segments, represented as special terminal nodes in the graph.
  */
-enum Terminal {
+public enum Terminal {
 
 	FOREGROUND, // a.k.a. the source
 	BACKGROUND; // a.k.a. the sink


### PR DESCRIPTION
Add public keyword to enum Terminal type, thus enables other plugins to
import GraphCut class.
