### PR TITLE
Use stack max value instead of 2^32 for 32-bit images

### DIFF
--- a/src/main/java/graphcut/Graph_Cut.java
+++ b/src/main/java/graphcut/Graph_Cut.java
@@ -11,6 +11,7 @@ import ij.io.FileInfo;
 import ij.plugin.PlugIn;
 import ij.process.ImageProcessor;
 import ij.process.LUT;
+import ij.process.StackStatistics;
 
 import java.awt.AlphaComposite;
 import java.awt.Component;
@@ -724,6 +725,9 @@ public class Graph_Cut<T extends RealType<T> & NativeType<T>> implements PlugIn
 	public void processSingleChannelImage(ImagePlus imp, ImagePlus edge, float dataWeight, float pottsWeight, float edgeWeight, ImagePlus seg) {
 
 		float maxValue     = (float)Math.pow(2, imp.getBitDepth());
+		if (imp.getBitDepth() == 32) {
+			maxValue = (float) new StackStatistics(imp).max;
+		}
 		Img<T> image     = ImagePlusAdapter.wrap(imp);
 		Img<T> edgeImage = null;
 		if (edge != null)


### PR DESCRIPTION
For 32-bit (float) images, it is unlikely that the actual data max is 2^32. When you a have a probability map, the range is between 0.0 and 1.0. Let's take the actual maximum of the stack's data to calculate the data weight.